### PR TITLE
Ensure bindir

### DIFF
--- a/manifests/darwin.pp
+++ b/manifests/darwin.pp
@@ -4,8 +4,11 @@ class masterless::darwin {
   $repodir = $masterless::repodir
   $bindir = $masterless::bindir
   $frequency = $masterless::frequency
-
-  file { "${bindir}/puppet-run":
+  
+  file { "${bindir}":
+    ensure => directory
+  }
+  -> file { "${bindir}/puppet-run":
     ensure => link,
     target => "${repodir}/meta/puppet-run"
   }

--- a/manifests/darwin.pp
+++ b/manifests/darwin.pp
@@ -4,8 +4,8 @@ class masterless::darwin {
   $repodir = $masterless::repodir
   $bindir = $masterless::bindir
   $frequency = $masterless::frequency
-  
-  file { "${bindir}":
+
+  file { $bindir:
     ensure => directory
   }
   -> file { "${bindir}/puppet-run":


### PR DESCRIPTION
This fixes the following failure on brand new installs where `bindir` doesn't exist. 
```
2018-12-23 23:02:29 Jareds-MacBook-Pro.local STARTING RUN
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Notice: Compiled catalog for jareds-macbook-pro.local in environment production in 0.81 seconds
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Error: Could not set 'link' on ensure: No such file or directory @ dir_chdir - /usr/local/bin (file: /opt/halyard/environments/production/modules/masterless/manifests/darwin.pp, line: 8)
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Error: Could not set 'link' on ensure: No such file or directory @ dir_chdir - /usr/local/bin (file: /opt/halyard/environments/production/modules/masterless/manifests/darwin.pp, line: 8)
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Wrapped exception:
2018-12-23 23:02:38 Jareds-MacBook-Pro.local No such file or directory @ dir_chdir - /usr/local/bin
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Error: /Stage[main]/Masterless::Darwin/File[/usr/local/bin/puppet-run]/ensure: change from 'absent' to 'link' failed: Could not set 'link' on ensure: No such file or directory @ dir_chdir - /usr/local/bin (file: /opt/halyard/environments/production/modules/masterless/manifests/darwin.pp, line: 8)
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Notice: /Stage[main]/Masterless::Darwin/File[/Library/LaunchDaemons/com.halyard.puppet-run.plist]/ensure: defined content as '{md5}66b18dc01ab3742d5b7d1668adc92379'
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Notice: /Stage[main]/Masterless::Darwin/Exec[Puppet-run refresh launchd]: Triggered 'refresh' from 1 event
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Error: Path /usr/local exists and is not the desired repository.
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Error: /Stage[main]/Homebrew/Vcsrepo[/usr/local]/ensure: change from 'absent' to 'present' failed: Path /usr/local exists and is not the desired repository.
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Notice: /Stage[main]/Sudoers/File[/etc/sudoers.d]/mode: mode changed '0755' to '0770'
2018-12-23 23:02:38 Jareds-MacBook-Pro.local Notice: /Stage[main]/Sudoers/File_line[include for sudoers.d]/ensure: created
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Hostname::Darwin/Sudoers::Allowed_command[hostname_scutil]/File[/etc/sudoers.d/hostname_scutil]/ensure: defined content as '{md5}ca2f8060ad796b3b46a1c94f5c0c32f8'
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Hostname::Darwin/Exec[set computername]/returns: executed successfully
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Hostname::Darwin/Exec[set hostname]/returns: executed successfully
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Hostname::Darwin/Exec[set localhostname]/returns: executed successfully
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Homebrew/Sudoers::Allowed_command[cask_installer]/File[/etc/sudoers.d/cask_installer]/ensure: defined content as '{md5}25452919488ea1fa3e558a4a4ac8d117'
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Error: /Stage[main]/Zsh/Package[zsh]: Provider brew is not functional on this host
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Error: /Stage[main]/Zsh/Package[zsh-completions]: Provider brew is not functional on this host
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Zsh/File_line[add zsh to /etc/shells]: Dependency Package[zsh] has failures: true
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Warning: /Stage[main]/Zsh/File_line[add zsh to /etc/shells]: Skipping because of failed dependencies
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Zsh/File[/etc/zprofile]: Dependency Package[zsh] has failures: true
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Warning: /Stage[main]/Zsh/File[/etc/zprofile]: Skipping because of failed dependencies
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: /Stage[main]/Zsh/Osx_shell[ghavil]: Dependency Package[zsh] has failures: true
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Warning: /Stage[main]/Zsh/Osx_shell[ghavil]: Skipping because of failed dependencies
2018-12-23 23:02:39 Jareds-MacBook-Pro.local Notice: Applied catalog in 1.34 seconds
2018-12-23 23:02:39 Jareds-MacBook-Pro.local ENDING RUN
```